### PR TITLE
feat: Make pages folder path variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,11 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" wiki.go
 
 FROM scratch
 WORKDIR /app
+ARG pages_folder="./pages"
+ENV GOWIKI_PAGES_PATH ${pages_folder}
 COPY --from=builder /app/wiki .
 COPY --from=builder /app/css ./css
 COPY --from=builder /app/js ./js
 COPY --from=builder /app/templates ./templates
-COPY --from=builder /app/pages /home/pages
+COPY --from=builder /app/pages ${GOWIKI_PAGES_PATH}
 ENTRYPOINT ["/app/wiki"]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Added features:
 
 - Index page at `/` path to show list of available pages.
 - Serve static content under `/js` and `/css`.
-- Create a new page from the Index page.
+- Create/Update page from the Index page.
 - Delete function. It is possible to delete pages from the index page and the view page.
 - Search function. Filter Wiki pages based on the searchterm provided.
 
@@ -15,7 +15,7 @@ Running the application will launch a webserver listening on the port 8888 by de
 
 After running the application open the `http://localhost:8888/` URL in a browser or any HTTP client to access the Index page of GoWiki site. Here there is a list of available pages that can be viewed and it is possible to create a new page. Navigation between the Index page and View/Edit are possible via links placed on the sites. Full CRUD functionalites have been implemented.
 
-Directly visiting the `http://localhost:8888/view/<page title>` URL it is possible to view the content of the `<page title>.txt` text file under the `/home/pages` folder. If the title does not exist a `Page Not Found` page will be presented with a button to create a page with the given title. Similar to the View directly visiting the `http://localhost:8888/edit/<page title>` URL it is possible to edit the content of the title if exists, otherwise new page can be created.
+Directly visiting the `http://localhost:8888/view/<page title>` URL it is possible to view the content of the `<page title>.txt` text file under the pages folder defined by `GOWIKI_PAGES_PATH` environment variable (`./pages` by default if it is not set). If the title does not exist a `Page Not Found` page will be presented with a button to create a page with the given title. Similar to the View directly visiting the `http://localhost:8888/edit/<page title>` URL it is possible to edit the content of the title if exists, otherwise new page can be created.
 
 
 ## Covered in this tutorial
@@ -40,13 +40,11 @@ type Page struct {
 
 1. List pages
 
-At the root path '/' the Index page shows the available Wiki pages (lists the .txt files under the `/home/pages` folder).
+At the root path '/' the Index page shows the available Wiki pages. Lists the .txt files under pages folder defined by `GOWIKI_PAGES_PATH` environment variable (`./pages` by default if it is not set).
 
 2. Create pages
 
 By visiting the `/view/<page title>` or `/edit/<page title>` URL with a page title that does not exist a new page can be created. In addition to that it is possible to provide a title on the Index page and clicking on the 'Create new page' button.
-
-At the root path '/' the Index page shows the available Wiki pages (lists the `.txt` files under the `/home/pages` folder).
 
 3. View pages
 
@@ -58,7 +56,7 @@ To edit a Title visit the `/edit/<page title>` URL or use the 'edit' link on a p
 
 5. Delete pages
 
-Delete links are available on the Index page next to the titles and on the view page. This removes the given `.txt` file under the `/home/pages` folder
+Delete links are available on the Index page next to the titles and on the view page. This removes the given `.txt` file under pages folder defined by `GOWIKI_PAGES_PATH` environment variable (`./pages` by default if it is not set).
 
 6. Search pages
 
@@ -71,7 +69,13 @@ It is possible to filter the listed Wiki pages on the Index site by providing a 
 $ go build wiki.go
 $ ./wiki
 ```
+This will run the GoWiki application listening on the default port 8888 and will store the pages created under the `./pages` folder. This can be changed by setting the following environment variables.
 
+```
+$ export GOWIKI_LISTEN_PORT=<specific port number>
+$ export GOWIKI_PAGES_PATH=<path to folder>
+$ ./wiki
+```
 
 ### Building Docker image and running the application in container
 
@@ -81,3 +85,15 @@ $ docker run -it --rm -p 8888:8888 <gowiki:tag>
 ```
 
 Choose an appropriate tag `<gowiki:tag>` for the image based on the application version.
+
+By using the `pages_folder` build argument it is possible to change the default path where the wiki pages will be stored in the container filesystem. For example, to view and store pages from the `/home/pages` build the image as follows:
+
+```
+$ docker build -t <gowiki:tag> --build-arg pages_folder=/home/pages .
+```
+
+Running the container with modified port and pages folder path specify the environment variable as follows:
+
+```
+$ docker run -it --rm -p 8888:<my port> -e GOWIKI_LISTEN_PORT=<my port> -e GOWIKI_PAGES_PATH=<my folder path> <gowiki:tag>
+```

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module example.com/wiki
 
-go 1.17
+go 1.22


### PR DESCRIPTION
Allow user to specify the folder path where the pages are read and written. This is necessary to support different uses cases where the files needs to be stored (e.g. Azure App Service will make persistent the /home folder inside the running container, so we would need to store the wiki pages under that path)